### PR TITLE
Fixed total_seconds callable being passed as request_time

### DIFF
--- a/octopus/core.py
+++ b/octopus/core.py
@@ -83,7 +83,7 @@ class Octopus(object):
             cookies=dict([(key, value) for key, value in response.cookies.items()]),
             text=response.text, effective_url=response.url,
             error=response.status_code > 399 and response.text or None,
-            request_time=response.elapsed and response.elapsed.total_seconds or 0
+            request_time=response.elapsed and response.elapsed.total_seconds() or 0
         )
 
     def enqueue(self, url, handler, method='GET', **kw):


### PR DESCRIPTION
Instead of passing the integer number of seconds for the request, the ``total_seconds`` method of ``timedelta`` was passed as ``Response.request_time``. This change fixes this.